### PR TITLE
Fix(Cart): backbutton bug

### DIFF
--- a/src/presentation/components/AppBar.tsx
+++ b/src/presentation/components/AppBar.tsx
@@ -12,13 +12,12 @@ interface Props {
 export function AppBar({
     title = `Mexi\nCesta`
 }: Props) {
-    const { navigation } = useAppNavigation();
-
+    const { navigation, route } = useAppNavigation();
     return (
         <View>
             <View style={styles.appBarContainer}>
                 <View style={styles.leftSide}>
-                    {navigation.canGoBack() && (
+                    {route.name !== 'CartList' && navigation.canGoBack() && (
                         <BackButton />
                     )}
                 </View>


### PR DESCRIPTION
Fix: BackButton visible on HomeScreen after navigating back

The BackButton was incorrectly rendered on the HomeScreen even when no screens were left in the navigation stack. Added an additional check to avoid showing the BackButton on HomeScreen.